### PR TITLE
Add kinetic damage type icon

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -79,6 +79,7 @@ const textColoring = [
 ]
 
 export const images = [
+  'kinetic' as const,
   'arc' as const,
   'solar' as const,
   'stasis' as const,


### PR DESCRIPTION
I was adding support for rendering other damage types in my app and wanted to ensure kinetic worked too but it wasn't a thing in Clarity yet, figured I'd add it. See https://github.com/Database-Clarity/Description-editor/pull/6