### PR TITLE
First crack at converter configuration for Vault Zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 converter
 *.js
 *.d.ts
+.DS_Store

--- a/src/converterSettings.ts
+++ b/src/converterSettings.ts
@@ -326,6 +326,66 @@ export const converterSettings: { [key: string]: DescriptionFilter } = {
       },
       link: ['[', ']', '(', ')']
     }
+  },
+  vaultZero: {
+    getFromPerk: {
+      lastUpload: false,
+      stats: true,
+      type: true,
+      uploadedBy: false,
+      updateTracker: false,
+      languages: ['en']
+    },
+    getFromDescription: {
+      formula: false,
+      link: true,
+      title: false,
+      table: false,
+      weaponTypes: false,
+      includeClassNames: [
+        'spacer',
+        
+        'stasis',
+        'arc',
+        'solar',
+        'void',
+        'strand',
+        
+        'primary',
+        'special',
+        'heavy',
+        
+        'pve',
+        'pvp',
+        
+        'background',
+        'bold'
+      ],
+      excludeClassNames: []
+    },
+    enhancedArrowReplacement: undefined,
+    editor: 'secondary',
+    optional: true,
+    toStringConverterOptions: {
+      classNames: {
+        stasis: ['[stasis]', ''],
+        arc: ['[arc]', ''],
+        solar: ['[solar]', ''],
+        void: ['[void]', ''],
+        strand: ['[strand]', ''],
+        
+        primary: ['[primary]', ''],
+        special: ['[special]', ''],
+        heavy: ['[heavy]', ''],
+
+        pve: ['[pve]', ''],
+        pvp: ['[pvp]', ''],
+
+        background: ['**', '**'],
+        bold: ['**', '**']
+      },
+      link: ['[', ']', '(', ')']
+    }
   }
 }
 export const getSettings = (name: string): DescriptionFilter => {

--- a/src/converterSettings.ts
+++ b/src/converterSettings.ts
@@ -363,7 +363,7 @@ export const converterSettings: { [key: string]: DescriptionFilter } = {
       ],
       excludeClassNames: []
     },
-    enhancedArrowReplacement: undefined,
+    enhancedArrowReplacement: '[enh]',
     editor: 'secondary',
     optional: true,
     toStringConverterOptions: {

--- a/src/converterSettings.ts
+++ b/src/converterSettings.ts
@@ -344,6 +344,7 @@ export const converterSettings: { [key: string]: DescriptionFilter } = {
       weaponTypes: false,
       includeClassNames: [
         'spacer',
+        'enhancedArrow',
         
         'stasis',
         'arc',


### PR DESCRIPTION
Hi there!

I've been chatting with Stardust over in the Clarity Discord about using the Clarity stats in my iOS app (`partner-ticket-57`). I created a first rev of a conversion configured based on `crayon.json`, as that seemed the closest to Markdown.

Please let me know if there's anything additional I need to do, or can do to help. Thank you!